### PR TITLE
Add Attack Reach for Players with Pehkui compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'org.parchmentmc.librarian.forgegradle'
 // Only edit below this line, the above code adds and enables the necessary things for Forge and Mixin to be setup.
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
+apply plugin: 'java-library'
 
 mixin {
     add sourceSets.main, "dungeons_libraries.refmap.json"
@@ -129,6 +130,7 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 repositories {
     maven { url 'https://dl.cloudsmith.io/public/geckolib3/geckolib/maven/' }
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -136,6 +138,8 @@ dependencies {
     annotationProcessor 'org.spongepowered:mixin:0.8.4:processor'
 
     implementation fg.deobf('software.bernie.geckolib:geckolib-forge-1.16.5:3.0.45')
+
+    api fg.deobf("com.github.Virtuoel:Pehkui:3.0.0-forge")
 
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html

--- a/src/main/java/com/infamous/dungeons_libraries/DungeonsLibraries.java
+++ b/src/main/java/com/infamous/dungeons_libraries/DungeonsLibraries.java
@@ -7,7 +7,9 @@ import com.infamous.dungeons_libraries.capabilities.enchantable.Enchantable;
 import com.infamous.dungeons_libraries.capabilities.enchantable.EnchantableStorage;
 import com.infamous.dungeons_libraries.capabilities.enchantable.IEnchantable;
 import com.infamous.dungeons_libraries.capabilities.summoning.*;
+import com.infamous.dungeons_libraries.compat.pehkui.PehkuiCompat;
 import com.infamous.dungeons_libraries.config.DungeonsLibrariesConfig;
+import com.infamous.dungeons_libraries.entities.EntityAttributes;
 import com.infamous.dungeons_libraries.network.NetworkHandler;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.CapabilityManager;
@@ -38,14 +40,16 @@ public class DungeonsLibraries
         MinecraftForge.EVENT_BUS.register(this);
 
         final IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+		EntityAttributes.ATTRIBUTES.register(modEventBus);
     }
 
-    private void setup(final FMLCommonSetupEvent event){
-        CapabilityManager.INSTANCE.register(ISummonable.class, new SummonableStorage(), Summonable::new);
-        CapabilityManager.INSTANCE.register(ISummoner.class, new SummonerStorage(), Summoner::new);
-        CapabilityManager.INSTANCE.register(IEnchantable.class, new EnchantableStorage(), Enchantable::new);
-        CapabilityManager.INSTANCE.register(IBuiltInEnchantments.class, new BuiltInEnchantmentsStorage(), BuiltInEnchantments::new);
-        event.enqueueWork(NetworkHandler::init);
-    }
+    private void setup(final FMLCommonSetupEvent event) {
+		CapabilityManager.INSTANCE.register(ISummonable.class, new SummonableStorage(), Summonable::new);
+		CapabilityManager.INSTANCE.register(ISummoner.class, new SummonerStorage(), Summoner::new);
+		CapabilityManager.INSTANCE.register(IEnchantable.class, new EnchantableStorage(), Enchantable::new);
+		CapabilityManager.INSTANCE.register(IBuiltInEnchantments.class, new BuiltInEnchantmentsStorage(), BuiltInEnchantments::new);
+		event.enqueueWork(NetworkHandler::init);
+		event.enqueueWork(PehkuiCompat::init);
+	}
 
 }

--- a/src/main/java/com/infamous/dungeons_libraries/compat/pehkui/PehkuiCompat.java
+++ b/src/main/java/com/infamous/dungeons_libraries/compat/pehkui/PehkuiCompat.java
@@ -1,0 +1,57 @@
+package com.infamous.dungeons_libraries.compat.pehkui;
+
+import com.infamous.dungeons_libraries.DungeonsLibraries;
+import net.minecraft.entity.Entity;
+import net.minecraftforge.fml.ModContainer;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.forgespi.language.IModInfo;
+import org.apache.logging.log4j.MarkerManager;
+
+import java.util.Optional;
+
+public final class PehkuiCompat {
+
+	private static IScaleUtil scaleUtil = new IScaleUtil.NullObject();
+
+	public static void init() {
+		Optional<? extends ModContainer> optional = ModList.get().getModContainerById("pehkui");
+		if (optional.isPresent()) {
+			IModInfo info = optional.get().getModInfo();
+			DungeonsLibraries.LOGGER.debug(MarkerManager.getMarker("Compat"), "setting up compatibility for mod {} ({})", info.getDisplayName(), info.getVersion());
+			scaleUtil = new PehkuiScaleUtil();
+		}
+	}
+
+	private PehkuiCompat() {}
+
+	public static float getPlayerReachScale(Entity player) {
+		return scaleUtil.getPlayerReachScale(player);
+	}
+
+	public static float getPlayerReachScale(Entity player, float partialTicks) {
+		return scaleUtil.getPlayerReachScale(player, partialTicks);
+	}
+
+	interface IScaleUtil {
+
+		float getPlayerReachScale(Entity player);
+
+		float getPlayerReachScale(Entity player, float partialTicks);
+
+		class NullObject implements IScaleUtil {
+
+			@Override
+			public float getPlayerReachScale(Entity player) {
+				return 1f;
+			}
+
+			@Override
+			public float getPlayerReachScale(Entity player, float partialTicks) {
+				return 1f;
+			}
+
+		}
+
+	}
+
+}

--- a/src/main/java/com/infamous/dungeons_libraries/compat/pehkui/PehkuiScaleUtil.java
+++ b/src/main/java/com/infamous/dungeons_libraries/compat/pehkui/PehkuiScaleUtil.java
@@ -1,0 +1,25 @@
+package com.infamous.dungeons_libraries.compat.pehkui;
+
+import net.minecraft.entity.Entity;
+import virtuoel.pehkui.util.ScaleUtils;
+
+/**
+ * works with Pehkui 2 & 3
+ */
+final class PehkuiScaleUtil implements PehkuiCompat.IScaleUtil {
+
+	PehkuiScaleUtil() {
+		ScaleUtils.getEntityReachScale(null); //checks if pehkui ScaleUtils is available, if not this will cause an error
+	}
+
+	@Override
+	public float getPlayerReachScale(Entity player) {
+		return ScaleUtils.getEntityReachScale(player);
+	}
+
+	@Override
+	public float getPlayerReachScale(Entity player, float partialTicks) {
+		return ScaleUtils.getEntityReachScale(player, partialTicks);
+	}
+
+}

--- a/src/main/java/com/infamous/dungeons_libraries/entities/EntityAttributeUtil.java
+++ b/src/main/java/com/infamous/dungeons_libraries/entities/EntityAttributeUtil.java
@@ -1,0 +1,63 @@
+package com.infamous.dungeons_libraries.entities;
+
+import net.minecraft.client.multiplayer.PlayerController;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.attributes.Attribute;
+import net.minecraft.entity.ai.attributes.ModifiableAttributeInstance;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.common.ForgeMod;
+
+import javax.annotation.Nullable;
+
+public final class EntityAttributeUtil {
+
+	private EntityAttributeUtil() {}
+
+	public static Attribute getAttackReach() {
+		return EntityAttributes.ATTACK_REACH.get();
+	}
+
+	public static Attribute getBlockReach() {
+		return ForgeMod.REACH_DISTANCE.get();
+	}
+
+	public static double getValueOrDefault(@Nullable LivingEntity entity, Attribute attribute) {
+		if (entity == null) return attribute.getDefaultValue();
+
+		ModifiableAttributeInstance instance = entity.getAttribute(attribute);
+		return instance != null ? instance.getValue() : attribute.getDefaultValue();
+	}
+
+	public static double getValueOrElse(@Nullable LivingEntity entity, Attribute attribute, double other) {
+		if (entity == null) return other;
+
+		ModifiableAttributeInstance instance = entity.getAttribute(attribute);
+		return instance != null ? instance.getValue() : other;
+	}
+
+	public static double getAttackReachDist(@Nullable LivingEntity entity) {
+		return getValueOrDefault(entity, getAttackReach());
+	}
+
+	/**
+	 * @param isCreative on client side this should be PlayerController#hasFarPickRange()
+	 */
+	public static double getAttackReachDist(@Nullable LivingEntity player, boolean isCreative) {
+		return getValueOrDefault(player, getAttackReach()) + (isCreative ? 3 : 0);
+	}
+
+	public static double getBlockReachDist(@Nullable LivingEntity entity) {
+		return getValueOrDefault(entity, getBlockReach());
+	}
+
+	@OnlyIn(Dist.CLIENT)
+	public static float getBlockReachDist(PlayerController playerController) {
+		return playerController.getPickRange(); //pehkui applies a mixin to PlayerController#getPickRange()
+	}
+
+	public static double getBlockReachDist(@Nullable LivingEntity player, boolean isCreative) {
+		return getValueOrDefault(player, getBlockReach()) - (isCreative ? 0 : 0.5); //player has a default block reach of 4.5 in survival and 5 in creative
+	}
+
+}

--- a/src/main/java/com/infamous/dungeons_libraries/entities/EntityAttributes.java
+++ b/src/main/java/com/infamous/dungeons_libraries/entities/EntityAttributes.java
@@ -1,0 +1,17 @@
+package com.infamous.dungeons_libraries.entities;
+
+
+import com.infamous.dungeons_libraries.DungeonsLibraries;
+import net.minecraft.entity.ai.attributes.Attribute;
+import net.minecraft.entity.ai.attributes.RangedAttribute;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.registries.DeferredRegister;
+
+public final class EntityAttributes {
+
+	public static final DeferredRegister<Attribute> ATTRIBUTES = DeferredRegister.create(Attribute.class, DungeonsLibraries.MODID);
+	public static final RegistryObject<Attribute> ATTACK_REACH = ATTRIBUTES.register("attack_reach", () -> new RangedAttribute("attribute.generic.attack_reach", 3, 0, 1024).setSyncable(true));
+
+	private EntityAttributes() {}
+
+}

--- a/src/main/java/com/infamous/dungeons_libraries/items/IRayTraceModeProvider.java
+++ b/src/main/java/com/infamous/dungeons_libraries/items/IRayTraceModeProvider.java
@@ -1,0 +1,51 @@
+package com.infamous.dungeons_libraries.items;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.RayTraceContext;
+
+public interface IRayTraceModeProvider {
+
+	/**
+	 * determines which block shape is hittable by the attack ray trace
+	 * <br><br>
+	 *
+	 * @return <p>
+	 * OUTLINE:  block shape (vanilla behavior, collides with all blocks)<br>
+	 * COLLIDER: collision block shape (ignores plants/grass, etc.)<br>
+	 * VISUAL:   visual block shape (some blocks are visually empty (Glass) or bigger (SoulSand) --> the ray will go through Glass)
+	 * </p>
+	 */
+	default RayTraceContext.BlockMode getRayTraceBlockModeForAttack(ItemStack stack, PlayerEntity player) {
+		return RayTraceContext.BlockMode.OUTLINE;
+	}
+
+	/**
+	 * determines which fluid is hittable by the attack ray trace
+	 */
+	default RayTraceContext.FluidMode getRayTraceFluidModeForAttack(ItemStack stack, PlayerEntity player) {
+		return RayTraceContext.FluidMode.NONE;
+	}
+
+	/**
+	 * determines which block shape is hittable by the pick block ray trace
+	 * <br><br>
+	 *
+	 * @return <p>
+	 * OUTLINE:  block shape (vanilla behavior, collides with all blocks)<br>
+	 * COLLIDER: collision block shape (ignores plants/grass, etc.)<br>
+	 * VISUAL:   visual block shape (some blocks are visually empty (Glass) or bigger (SoulSand) --> the ray will go through Glass)
+	 * </p>
+	 */
+	default RayTraceContext.BlockMode getRayTraceBlockModeForPickBlock(ItemStack stack, PlayerEntity player) {
+		return RayTraceContext.BlockMode.OUTLINE;
+	}
+
+	/**
+	 * determines which fluid is hittable by the pick block ray trace
+	 */
+	default RayTraceContext.FluidMode getRayTraceFluidModeForPickBlock(ItemStack stack, PlayerEntity player) {
+		return RayTraceContext.FluidMode.NONE;
+	}
+
+}

--- a/src/main/java/com/infamous/dungeons_libraries/mixin/PlayerEntityMixin.java
+++ b/src/main/java/com/infamous/dungeons_libraries/mixin/PlayerEntityMixin.java
@@ -1,0 +1,45 @@
+package com.infamous.dungeons_libraries.mixin;
+
+import com.infamous.dungeons_libraries.DungeonsLibraries;
+import com.infamous.dungeons_libraries.compat.pehkui.PehkuiCompat;
+import com.infamous.dungeons_libraries.entities.EntityAttributeUtil;
+import com.infamous.dungeons_libraries.entities.EntityAttributes;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.ai.attributes.AttributeModifierMap;
+import net.minecraft.entity.player.PlayerEntity;
+import org.apache.logging.log4j.MarkerManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PlayerEntity.class)
+public abstract class PlayerEntityMixin {
+
+	/**
+	 * @author Elenterius
+	 */
+	@Inject(method = "createAttributes", at = @At(value = "RETURN"))
+	private static void dungeonsLibraries_onCreateAttributes(CallbackInfoReturnable<AttributeModifierMap.MutableAttribute> cir) {
+		DungeonsLibraries.LOGGER.debug(MarkerManager.getMarker("ATTRIBUTE INJECTION"), "adding attack reach attribute to player");
+		cir.getReturnValue().add(EntityAttributes.ATTACK_REACH.get());
+	}
+
+	/**
+	 * allow sweep attacks with larger attack reach
+	 *
+	 * @author Elenterius
+	 */
+	//TODO: check if this is broken in 1.17/1.18 --> Reason: forge added custom sweep hit boxes in 1.17 (#7981)
+	@Redirect(method = "attack", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;distanceToSqr(Lnet/minecraft/entity/Entity;)D"))
+	private double dungeonsLibraries_DistanceToSqProxy(PlayerEntity player, Entity targetEntity) {
+		float scale = Math.max(PehkuiCompat.getPlayerReachScale(player), 1f);
+		double reachDist = EntityAttributeUtil.getAttackReachDist(player);
+		double maxReachDistSq = scale * scale * reachDist * reachDist;
+
+		double distSq = player.distanceToSqr(targetEntity);
+		return distSq < maxReachDistSq ? Double.MIN_VALUE : Double.MAX_VALUE;
+	}
+
+}

--- a/src/main/java/com/infamous/dungeons_libraries/mixin/ServerPlayNetHandlerMixin.java
+++ b/src/main/java/com/infamous/dungeons_libraries/mixin/ServerPlayNetHandlerMixin.java
@@ -1,0 +1,65 @@
+package com.infamous.dungeons_libraries.mixin;
+
+import com.infamous.dungeons_libraries.DungeonsLibraries;
+import com.infamous.dungeons_libraries.compat.pehkui.PehkuiCompat;
+import com.infamous.dungeons_libraries.entities.EntityAttributeUtil;
+import com.infamous.dungeons_libraries.utils.RayTraceUtil;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.network.play.ServerPlayNetHandler;
+import net.minecraft.network.play.client.CUseEntityPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ServerPlayNetHandler.class)
+public abstract class ServerPlayNetHandlerMixin {
+
+	@Shadow
+	public ServerPlayerEntity player;
+
+	/**
+	 * @author Elenterius
+	 */
+	@Unique
+	private double getMaxReachDist(ServerPlayerEntity player, CUseEntityPacket.Action action) {
+		float scale = Math.max(PehkuiCompat.getPlayerReachScale(player), 1f);
+		if (action == CUseEntityPacket.Action.ATTACK) {
+			return scale * EntityAttributeUtil.getAttackReachDist(player, player.isCreative());
+		}
+		else {
+			return scale * (EntityAttributeUtil.getBlockReachDist(player, true) + 1d);
+		}
+	}
+
+	/**
+	 * Fixes the issue where for players with a low maxReachDist the target's position can be outside the maxReachDist while the bounding box of the target is still within range.
+	 *
+	 * @author Elenterius
+	 */
+	@Redirect(method = "handleInteract", require = 0, at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/ServerPlayerEntity;distanceToSqr(Lnet/minecraft/entity/Entity;)D"))
+	private double dungeonsLibraries_distanceToSqProxy(ServerPlayerEntity player, Entity targetOfClient, CUseEntityPacket packet) {
+
+		final double maxReachDist = getMaxReachDist(player, packet.getAction());
+		final double distSqToBBox = RayTraceUtil.distanceSqToInflatedBoundingBox(player, targetOfClient, maxReachDist);
+		final double maxReachDistSq = maxReachDist * maxReachDist;
+
+		//TODO: don't trust the client? And perform a block raytrace to prevent attacks through walls?
+
+		//For testing spawn a large slime and attack in survival mode or with reduced attack reach (e.g. /summon minecraft:slime ~ ~ ~ {Size: 10})
+		DungeonsLibraries.LOGGER.debug(() -> {
+			double distSqToPosition = player.distanceToSqr(targetOfClient);
+			return String.format(
+					"\nmaxReach[dist: %f, distSq: %f]\n" +
+							"|-> old >> distSqToPosition[%f] is within maxReachDistSq: %s\n" +
+							"|-> new >>     distSqToBBox[%f] is within maxReachDistSq: %s",
+					maxReachDist, maxReachDistSq, distSqToPosition, distSqToPosition < maxReachDistSq, distSqToBBox, distSqToBBox < maxReachDistSq
+			);
+		});
+
+		return distSqToBBox < maxReachDistSq ? Double.MIN_VALUE : Double.MAX_VALUE;
+	}
+
+}

--- a/src/main/java/com/infamous/dungeons_libraries/mixin/client/ClientPlayerReachMixin.java
+++ b/src/main/java/com/infamous/dungeons_libraries/mixin/client/ClientPlayerReachMixin.java
@@ -1,0 +1,141 @@
+package com.infamous.dungeons_libraries.mixin.client;
+
+import com.infamous.dungeons_libraries.compat.pehkui.PehkuiCompat;
+import com.infamous.dungeons_libraries.entities.EntityAttributeUtil;
+import com.infamous.dungeons_libraries.items.IRayTraceModeProvider;
+import com.infamous.dungeons_libraries.utils.RayTraceUtil;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockRayTraceResult;
+import net.minecraft.util.math.RayTraceContext;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.util.math.vector.Vector3d;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.util.Objects;
+
+/**
+ * Enables increased and decreased (attack) reach distance
+ *
+ * @author Elenterius
+ */
+@Mixin(GameRenderer.class)
+public abstract class ClientPlayerReachMixin {
+
+	@Shadow
+	@Final
+	private Minecraft minecraft;
+
+	@Unique
+	private Entity camera;
+
+	@Unique
+	private double maxAttackReachDist;
+
+	@Inject(method = "pick", at = @At(value = "INVOKE", target = "Lnet/minecraft/profiler/IProfiler;push(Ljava/lang/String;)V"), locals = LocalCapture.CAPTURE_FAILHARD)
+	private void dungeonsLibraries_captureCameraEntity(float partialTicks, CallbackInfo ci, Entity entity) {
+		camera = entity; //not null at this point
+
+		final float scale = PehkuiCompat.getPlayerReachScale(camera, partialTicks);
+		maxAttackReachDist = scale * EntityAttributeUtil.getAttackReachDist(minecraft.player, Objects.requireNonNull(minecraft.gameMode).hasFarPickRange());
+	}
+
+	@Redirect(method = "pick", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;pick(DFZ)Lnet/minecraft/util/math/RayTraceResult;"))
+	private RayTraceResult dungeonsLibraries_PickBlockProxy(Entity instance, double rayTraceDistance, float partialTicks, boolean rayTraceFluids) {
+		//block reach value is already changed (pehkui applies a mixin to PlayerController#getPickRange() when not in creative mode)
+		// 0.9 * block_reach vs block_reach - 0.5
+		final float blockReachDist = Objects.requireNonNull(minecraft.gameMode).getPickRange();
+
+		if (blockReachDist > 0) {
+
+			ItemStack heldStack = Objects.requireNonNull(minecraft.player).getMainHandItem();
+			if (heldStack.getItem() instanceof IRayTraceModeProvider) {
+				IRayTraceModeProvider provider = (IRayTraceModeProvider) heldStack.getItem();
+				RayTraceContext.BlockMode blockMode = provider.getRayTraceBlockModeForPickBlock(heldStack, minecraft.player);
+				RayTraceContext.FluidMode fluidMode = provider.getRayTraceFluidModeForPickBlock(heldStack, minecraft.player);
+				return RayTraceUtil.pickBlock(camera, partialTicks, blockReachDist, blockMode, fluidMode);
+			}
+
+			return instance.pick(blockReachDist, partialTicks, rayTraceFluids);
+		}
+		else {
+			//prevent the hitting of any block
+			//fixes forge bug where block reach <= 0 returns a hit and not a miss
+			Vector3d eyePosition = camera.getEyePosition(partialTicks);
+			Vector3d lookVec = camera.getViewVector(partialTicks);
+			return BlockRayTraceResult.miss(eyePosition, Direction.getNearest(lookVec.x, lookVec.y, lookVec.z), new BlockPos(eyePosition));
+		}
+	}
+
+	/**
+	 * if we hit a block reduce the max ray distance of the EntityRayTrace --> prevents attacks through walls on the client side
+	 *
+	 * @param rayStartPos vector3d = entity.getEyePosition(pPartialTicks)
+	 * @return maxAttackReachDistanceSquare
+	 */
+	@Redirect(method = "pick", at = @At(value = "INVOKE", ordinal = 0, target = "Lnet/minecraft/util/math/vector/Vector3d;distanceToSqr(Lnet/minecraft/util/math/vector/Vector3d;)D"))
+	private double dungeonsLibraries_GetModifiedAttackReachProxy(Vector3d hitPosition, Vector3d rayStartPos, float partialTicks) {
+		// We ignore the previous block raytrace hit result and perform a second raytrace (independent of block reach)
+		// using the attack reach distance to determine if the targeted entity is not obstructed by blocks (prevent attacks through walls)
+
+		RayTraceResult hitResult;
+		ItemStack heldStack = Objects.requireNonNull(minecraft.player).getMainHandItem();
+		if (heldStack.getItem() instanceof IRayTraceModeProvider) {
+			IRayTraceModeProvider provider = (IRayTraceModeProvider) heldStack.getItem();
+			RayTraceContext.BlockMode blockMode = provider.getRayTraceBlockModeForAttack(heldStack, minecraft.player);
+			RayTraceContext.FluidMode fluidMode = provider.getRayTraceFluidModeForAttack(heldStack, minecraft.player);
+
+			/*
+			 * In COLLIDER BlockMode:
+			 * decreasing block reach allows attacks to pass through grass/plant blocks
+			 * >>> This is proper behavior because block reach determines what blocks can be interacted with,
+			 * >>> so any blocks outside the block reach shouldn't be able to be targeted & interacted with when the attack ray trace is done
+			 * */
+			hitResult = RayTraceUtil.pickBlock(camera, partialTicks, maxAttackReachDist, blockMode, fluidMode);
+		}
+		else {
+			hitResult = RayTraceUtil.pickBlock(camera, partialTicks, maxAttackReachDist, RayTraceContext.BlockMode.OUTLINE, false);
+		}
+
+		if (hitResult.getType() != RayTraceResult.Type.MISS) {
+			//we hit a wall, reduce the ray distance for the EntityRayTrace --> blocks attacks through walls (block)
+			return hitResult.getLocation().distanceToSqr(rayStartPos);
+		}
+
+		return maxAttackReachDist * maxAttackReachDist;
+	}
+
+	/**
+	 * @return start position of the ray
+	 */
+	@Redirect(method = "pick", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/vector/Vector3d;add(DDD)Lnet/minecraft/util/math/vector/Vector3d;"))
+	private Vector3d dungeonsLibraries_VectorAddProxy(Vector3d instance, double pX, double pY, double pZ) {
+		return instance.add(camera.getViewVector(1f).scale(maxAttackReachDist));
+	}
+
+	@ModifyArg(method = "pick", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/math/vector/Vector3d;scale(D)Lnet/minecraft/util/math/vector/Vector3d;"), index = 0)
+	private double dungeonsLibraries_AdjustVectorScale(double d0) {
+		return maxAttackReachDist;
+	}
+
+	@Redirect(method = "pick", at = @At(value = "INVOKE", ordinal = 1, target = "Lnet/minecraft/util/math/vector/Vector3d;distanceToSqr(Lnet/minecraft/util/math/vector/Vector3d;)D"))
+	private double dungeonsLibraries_DistanceToSqrProxy(Vector3d instance, Vector3d hitVec) {
+		double distSq = instance.distanceToSqr(hitVec);
+		double maxReachDistSq = maxAttackReachDist * maxAttackReachDist;
+		return distSq > maxReachDistSq ? Double.MAX_VALUE : Double.MIN_VALUE;
+	}
+
+}

--- a/src/main/java/com/infamous/dungeons_libraries/utils/RayTraceUtil.java
+++ b/src/main/java/com/infamous/dungeons_libraries/utils/RayTraceUtil.java
@@ -1,0 +1,59 @@
+package com.infamous.dungeons_libraries.utils;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.RayTraceContext;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.util.math.vector.Vector3d;
+
+import java.util.Optional;
+
+public final class RayTraceUtil {
+
+	private RayTraceUtil() {}
+
+	public static RayTraceResult pickBlock(Entity entity, float partialTicks, double rayDist, RayTraceContext.BlockMode blockMode, boolean traceFluids) {
+		return pickBlock(entity, partialTicks, rayDist, blockMode, traceFluids ? RayTraceContext.FluidMode.ANY : RayTraceContext.FluidMode.NONE);
+	}
+
+	public static RayTraceResult pickBlock(Entity entity, float partialTicks, double rayDist, RayTraceContext.BlockMode blockMode, RayTraceContext.FluidMode fluidMode) {
+		Vector3d startPos = entity.getEyePosition(partialTicks);
+		Vector3d lookVec = entity.getViewVector(partialTicks);
+		Vector3d endPos = startPos.add(lookVec.x * rayDist, lookVec.y * rayDist, lookVec.z * rayDist);
+		return entity.level.clip(new RayTraceContext(startPos, endPos, blockMode, fluidMode, entity));
+	}
+
+	/**
+	 * instead of getting the distance between two positions, tries to get the distance between the position of the source and the inflated bounding box of the target
+	 */
+	public static double distanceSqToInflatedBoundingBox(Entity source, Entity target, double maxDist) {
+		//make it easier to hit small targets
+		return distanceSqToBoundingBox(source, target, 0.3f, maxDist);
+	}
+
+	/**
+	 * instead of getting the distance between two points, tries to get the distance between the position of the source and the bounding box of the target
+	 *
+	 * @param inflate inflates the target aabb if the value is not zero, a possible input value could be {@link Entity#getPickRadius()}
+	 */
+	public static double distanceSqToBoundingBox(Entity source, Entity target, float inflate, double maxDist) {
+		//create "ray"
+		Vector3d startPos = source.getEyePosition(1f);
+		Vector3d direction = target.position().subtract(startPos).normalize();
+		Vector3d endPos = startPos.add(direction.scale(maxDist));
+
+		AxisAlignedBB aabb = inflate != 0f ? target.getBoundingBox().inflate(inflate) : target.getBoundingBox();
+
+		//tries to get the "intersection point" of the aabb with the ray
+		Optional<Vector3d> optional = aabb.clip(startPos, endPos);
+		if (aabb.contains(startPos)) {
+			return startPos.distanceToSqr(optional.orElse(startPos));
+		}
+		else if (optional.isPresent()) {
+			return startPos.distanceToSqr(optional.get());
+		}
+
+		return source.distanceToSqr(target); //fallback
+	}
+
+}

--- a/src/main/resources/assets/dungeons_libraries/lang/en_us.json
+++ b/src/main/resources/assets/dungeons_libraries/lang/en_us.json
@@ -6,5 +6,10 @@
   "commands.mobEnchantment.clear.specific.success.single": "Removed mob enchantment %s from %s",
   "commands.mobEnchantment.clear.specific.success.multiple": "Removed mob enchantment %s from %s targets",
   "commands.mobEnchantment.give.failed": "Unable to apply this mobEnchantment (target likely already has it)",
-  "commands.mobEnchantment.clear.everything.failed": "Target has no mobEnchantments to remove"
+  "commands.mobEnchantment.clear.everything.failed": "Target has no mobEnchantments to remove",
+
+  "attribute.name.generic.reach_distance": "Block Reach",
+  "attribute.generic.attack_reach": "Attack Reach",
+  "generic.reachDistance": "Block Reach",
+  "generic.attackReach": "Attack Reach"
 }

--- a/src/main/resources/dungeons_libraries.mixins.json
+++ b/src/main/resources/dungeons_libraries.mixins.json
@@ -5,10 +5,13 @@
   "minVersion": "0.8",
   "refmap": "dungeons_libraries.refmap.json",
   "mixins": [
+    "EnchantmentHelperMixin",
     "GeoEntityRendererMixin",
-    "EnchantmentHelperMixin"
+    "PlayerEntityMixin",
+    "ServerPlayNetHandlerMixin"
   ],
   "client": [
+    "client.ClientPlayerReachMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/test/java/com/infamous/dungeons_libraries/test/mod/AttackReachStuff.java
+++ b/src/test/java/com/infamous/dungeons_libraries/test/mod/AttackReachStuff.java
@@ -1,0 +1,124 @@
+package com.infamous.dungeons_libraries.test.mod;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import com.infamous.dungeons_libraries.entities.EntityAttributeUtil;
+import com.infamous.dungeons_libraries.items.IRayTraceModeProvider;
+import net.minecraft.entity.ai.attributes.Attribute;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.EquipmentSlotType;
+import net.minecraft.item.*;
+import net.minecraft.util.math.RayTraceContext;
+import net.minecraftforge.common.util.Lazy;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.DeferredRegister;
+
+import java.util.UUID;
+
+@Mod.EventBusSubscriber(modid = TestMod.MOD_ID) //forces loading of class
+public final class AttackReachStuff {
+
+	public static final DeferredRegister<Item> ITEMS = TestMod.ITEMS;
+
+	private AttackReachStuff() {}
+
+//	public static RegistryObject<Enchantment>  CORRUPTED_ATTACK_REACH = ENCHANTMENTS.register("corrupted_attack_reach", () -> new Enchantment());
+
+	private static Item.Properties getDefaultProperties() {
+		return new Item.Properties().tab(TestMod.ITEM_GROUP);
+	}
+
+	public static RegistryObject<Item> VERY_SHORT_SWORD = ITEMS.register("very_short_sword", () -> new TestSwordItem(ItemTier.DIAMOND, -1.5f, 3, -1.5f, getDefaultProperties()));
+	public static RegistryObject<Item> LONG_SWORD = ITEMS.register("long_sword", () -> new TestSwordItem(ItemTier.DIAMOND, 2f, 3, -2.8f, getDefaultProperties()));
+
+	public static RegistryObject<Item> SHORT_SWORD = ITEMS.register("short_sword", () -> new TestSwordItem(ItemTier.DIAMOND, -1f, 3, -2f, getDefaultProperties()) {
+		@Override
+		protected void addAdditionalAttributeModifiers(ImmutableMultimap.Builder<Attribute, AttributeModifier> builder) {
+			//test item with increased block reach and reduced attack reach
+			UUID uuid = UUID.fromString("d77d85ea-0112-4aad-9c18-1bc2a0b70f9e");
+			builder.put(EntityAttributeUtil.getBlockReach(), new AttributeModifier(uuid, "Weapon modifier", 3, AttributeModifier.Operation.ADDITION));
+		}
+	});
+
+	public static RegistryObject<Item> VERY_LONG_SWORD = ITEMS.register("very_long_sword", () -> new TestSwordItem(ItemTier.DIAMOND, 4f, 3, -3f, getDefaultProperties()) {
+		@Override
+		public RayTraceContext.BlockMode getRayTraceBlockModeForPickBlock(ItemStack stack, PlayerEntity player) {
+			return RayTraceContext.BlockMode.COLLIDER;
+		}
+
+		@Override
+		public RayTraceContext.BlockMode getRayTraceBlockModeForAttack(ItemStack stack, PlayerEntity player) {
+			return RayTraceContext.BlockMode.COLLIDER;
+		}
+	});
+
+	//sword that sets block reach to zero (vanilla attack reach)
+	public static RegistryObject<Item> ETHEREAL_SWORD = ITEMS.register("ethereal_sword", () -> new TestSwordItem(ItemTier.DIAMOND, 0f, 3, -2.4f, getDefaultProperties()) {
+		@Override
+		protected void addAdditionalAttributeModifiers(ImmutableMultimap.Builder<Attribute, AttributeModifier> builder) {
+			UUID uuid = UUID.fromString("43483e9b-a2f2-4673-bb6b-1157653584f9");
+			builder.put(EntityAttributeUtil.getBlockReach(), new AttributeModifier(uuid, "Weapon modifier", -1f, AttributeModifier.Operation.MULTIPLY_TOTAL));
+		}
+
+		@Override
+		public RayTraceContext.BlockMode getRayTraceBlockModeForAttack(ItemStack stack, PlayerEntity player) {
+			return RayTraceContext.BlockMode.VISUAL;
+		}
+	});
+
+	//pickaxe that sets attack reach to zero
+	public static RegistryObject<Item> ETHEREAL_PICKAXE = ITEMS.register("ethereal_pickaxe", () -> new EtherealPickaxeItem(ItemTier.DIAMOND, 1, -2.8f, getDefaultProperties()));
+
+
+	public static final UUID ATTACK_REACH_UUID = UUID.fromString("9bc1ee60-2d06-40d2-aeb5-1292cc416f72");
+
+	static class TestSwordItem extends SwordItem implements IRayTraceModeProvider {
+
+		final Lazy<Multimap<Attribute, AttributeModifier>> lazyAttributeModifiers;
+
+		public TestSwordItem(IItemTier tier, float attackReachModifier, int attackDamageModifier, float attackSpeedModifier, Properties properties) {
+			super(tier, attackDamageModifier, attackSpeedModifier, properties);
+			lazyAttributeModifiers = Lazy.of(() -> {
+				ImmutableMultimap.Builder<Attribute, AttributeModifier> builder = ImmutableMultimap.builder();
+				builder.putAll(super.getDefaultAttributeModifiers(EquipmentSlotType.MAINHAND));
+				builder.put(EntityAttributeUtil.getAttackReach(), new AttributeModifier(ATTACK_REACH_UUID, "Weapon modifier", attackReachModifier, AttributeModifier.Operation.ADDITION));
+				addAdditionalAttributeModifiers(builder);
+				return builder.build();
+			});
+		}
+
+		protected void addAdditionalAttributeModifiers(ImmutableMultimap.Builder<Attribute, AttributeModifier> builder) {}
+
+		@Override
+		public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlotType equipmentSlotType) {
+			return equipmentSlotType == EquipmentSlotType.MAINHAND ? lazyAttributeModifiers.get() : super.getDefaultAttributeModifiers(equipmentSlotType);
+		}
+
+	}
+
+	//pickaxe that can't attack entities
+	static class EtherealPickaxeItem extends PickaxeItem {
+
+		final Lazy<Multimap<Attribute, AttributeModifier>> lazyAttributeModifiers;
+
+		public EtherealPickaxeItem(IItemTier tier, int attackDamageModifier, float attackSpeedModifier, Properties properties) {
+			super(tier, attackDamageModifier, attackSpeedModifier, properties);
+			lazyAttributeModifiers = Lazy.of(() -> {
+				ImmutableMultimap.Builder<Attribute, AttributeModifier> builder = ImmutableMultimap.builder();
+				builder.putAll(super.getDefaultAttributeModifiers(EquipmentSlotType.MAINHAND));
+				builder.put(EntityAttributeUtil.getAttackReach(), new AttributeModifier(ATTACK_REACH_UUID, "Tool modifier", -1f, AttributeModifier.Operation.MULTIPLY_TOTAL)); // sets attack reach to zero
+				builder.put(EntityAttributeUtil.getBlockReach(), new AttributeModifier(UUID.fromString("7d67c367-3a17-461a-b362-e7b75b2709fb"), "Tool modifier", 2, AttributeModifier.Operation.ADDITION));
+				return builder.build();
+			});
+		}
+
+		@Override
+		public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlotType equipmentSlotType) {
+			return equipmentSlotType == EquipmentSlotType.MAINHAND ? lazyAttributeModifiers.get() : super.getDefaultAttributeModifiers(equipmentSlotType);
+		}
+
+	}
+
+}

--- a/src/test/java/com/infamous/dungeons_libraries/test/mod/TestMod.java
+++ b/src/test/java/com/infamous/dungeons_libraries/test/mod/TestMod.java
@@ -1,5 +1,6 @@
 package com.infamous.dungeons_libraries.test.mod;
 
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -10,6 +11,8 @@ import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -45,8 +48,12 @@ public class TestMod {
 		}
 	};
 
+	public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MOD_ID);
+
 	public TestMod() {
 		final IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+
+		ITEMS.register(modEventBus);
 		modEventBus.addListener(this::setup);
 	}
 

--- a/src/test/resources/assets/test_dungeons_libraries/lang/en_us.json
+++ b/src/test/resources/assets/test_dungeons_libraries/lang/en_us.json
@@ -1,3 +1,10 @@
 {
-  "itemGroup.test_dungeons_libraries": "[TEST] Dungeons Libraries"
+  "itemGroup.test_dungeons_libraries": "[TEST] Dungeons Libraries",
+
+  "item.test_dungeons_libraries.very_short_sword": "[TEST] very small attack reach",
+  "item.test_dungeons_libraries.short_sword": "[TEST] small attack reach with large block reach",
+  "item.test_dungeons_libraries.long_sword": "[TEST] large attack reach",
+  "item.test_dungeons_libraries.very_long_sword": "[TEST] very large attack reach, with collider ray trace",
+  "item.test_dungeons_libraries.ethereal_sword": "[TEST] vanilla attack reach with zero block reach",
+  "item.test_dungeons_libraries.ethereal_pickaxe": "[TEST] zero attack reach with large block reach"
 }

--- a/src/test/resources/assets/test_dungeons_libraries/models/item/ethereal_pickaxe.json
+++ b/src/test/resources/assets/test_dungeons_libraries/models/item/ethereal_pickaxe.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/handheld",
+  "textures": {
+    "layer0": "minecraft:item/diamond_pickaxe"
+  }
+}

--- a/src/test/resources/assets/test_dungeons_libraries/models/item/ethereal_sword.json
+++ b/src/test/resources/assets/test_dungeons_libraries/models/item/ethereal_sword.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/handheld",
+  "textures": {
+    "layer0": "minecraft:item/diamond_sword"
+  }
+}

--- a/src/test/resources/assets/test_dungeons_libraries/models/item/long_sword.json
+++ b/src/test/resources/assets/test_dungeons_libraries/models/item/long_sword.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/handheld",
+  "textures": {
+    "layer0": "minecraft:item/diamond_sword"
+  }
+}

--- a/src/test/resources/assets/test_dungeons_libraries/models/item/short_sword.json
+++ b/src/test/resources/assets/test_dungeons_libraries/models/item/short_sword.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/handheld",
+  "textures": {
+    "layer0": "minecraft:item/diamond_sword"
+  }
+}

--- a/src/test/resources/assets/test_dungeons_libraries/models/item/very_long_sword.json
+++ b/src/test/resources/assets/test_dungeons_libraries/models/item/very_long_sword.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/handheld",
+  "textures": {
+    "layer0": "minecraft:item/diamond_sword"
+  }
+}

--- a/src/test/resources/assets/test_dungeons_libraries/models/item/very_short_sword.json
+++ b/src/test/resources/assets/test_dungeons_libraries/models/item/very_short_sword.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/handheld",
+  "textures": {
+    "layer0": "minecraft:item/diamond_sword"
+  }
+}


### PR DESCRIPTION
Implements `Attack Reach` attribute
-  independent of `Block Reach` (like Dungeons Gear)
- Pehkui 3 compatibility (2 should also work, i just didn't check if the mixins are the same)
- properly handles decreased attack reach 
- allow items to determine which Block & Fluid Mode is used for the pick block and attack RayTrace

## Pehkui Compatibility
This is achieved by basically "overriding/ignoring" the mixin changes done by Pehkui and calculating the scaled `Attack Reach` (independent of `Block Reach`) ourselves using the Pehkui ScaleUtils.

IMO this jank solution should be replaced with a clean overwrite mixin and a pull request to pehkui to disable their mixins when Dungeons Libraries is present.

## Behavior Changes

### Creative Attack Reach
`creative_attack_reach = (attack_reach + 3)`  (default attack reach = 3, so default creative reach is 6)

### Block Reach 
Fixed the forge "bug" where players with `zero block reach` are still able to hit the block that is present at their eye position (e.g. when inside tall grass/plants).

### Server Side Distance Check
Instead of  calculating the distance between the player and targeted Entity using their positions, we use the distance between the player position and the bounding box of the targeted Entity. This means players with reduced attack reach will still be able to attack Entities with large bounding boxes. (e.g. slime with a size of 10)
