### PR TITLE
Update AttacherBuiltInEnchantments.java

### DIFF
--- a/src/main/java/com/infamous/dungeons_libraries/capabilities/builtinenchants/AttacherBuiltInEnchantments.java
+++ b/src/main/java/com/infamous/dungeons_libraries/capabilities/builtinenchants/AttacherBuiltInEnchantments.java
@@ -45,6 +45,9 @@ public class AttacherBuiltInEnchantments {
 
     public static void attach(final AttachCapabilitiesEvent<ItemStack> event) {
         final AttacherBuiltInEnchantments.BuiltInEnchantmentsProvider provider = new AttacherBuiltInEnchantments.BuiltInEnchantmentsProvider(event.getObject());
-        event.addCapability(AttacherBuiltInEnchantments.BuiltInEnchantmentsProvider.IDENTIFIER, provider);
+        
+        if ( event.getObject().isEnchantable() && event.getObject().getMaxStackSize() == 1 ) {
+            event.addCapability(AttacherBuiltInEnchantments.BuiltInEnchantmentsProvider.IDENTIFIER, provider);
+        }
     }
 }


### PR DESCRIPTION
Fixes issue #35 by limiting capability attachments to items that cant be stacked and be enchanted. 

Tested on latest commit and AE2 version 12.9.2 and issue has been resolved. All prior AE2 recipes, import/exports, storage drives, etc will all have to be updated to remove the additional tag on items. 