### PR TITLE
Fixed #35 for 1.18

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
-mod_version=2.0.5-beta
+mod_version=2.0.5-beta-fixed
 mc_version=1.18.2
 forge_version=40.1.80
 geckolib_version=3.0.55

--- a/src/main/java/com/infamous/dungeons_libraries/capabilities/builtinenchants/AttacherBuiltInEnchantments.java
+++ b/src/main/java/com/infamous/dungeons_libraries/capabilities/builtinenchants/AttacherBuiltInEnchantments.java
@@ -1,5 +1,7 @@
 package com.infamous.dungeons_libraries.capabilities.builtinenchants;
 
+import org.jetbrains.annotations.NotNull;
+
 import com.infamous.dungeons_libraries.capabilities.ModCapabilities;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -10,8 +12,6 @@ import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
-import org.jetbrains.annotations.NotNull;
-
 import static com.infamous.dungeons_libraries.DungeonsLibraries.MODID;
 
 public class AttacherBuiltInEnchantments {
@@ -45,6 +45,9 @@ public class AttacherBuiltInEnchantments {
 
     public static void attach(final AttachCapabilitiesEvent<ItemStack> event) {
         final AttacherBuiltInEnchantments.BuiltInEnchantmentsProvider provider = new AttacherBuiltInEnchantments.BuiltInEnchantmentsProvider(event.getObject());
-        event.addCapability(AttacherBuiltInEnchantments.BuiltInEnchantmentsProvider.IDENTIFIER, provider);
+
+        if (event.getObject().isEnchantable() && event.getObject().getMaxStackSize() == 1) {
+            event.addCapability(AttacherBuiltInEnchantments.BuiltInEnchantmentsProvider.IDENTIFIER, provider);
+        }
     }
 }


### PR DESCRIPTION
Fixed […sues/35](https://github.com/Infamous-Misadventures/Dungeons-Libraries/issues/35) and is copy of https://github.com/Infamous-Misadventures/Dungeons-Libraries/pull/43 just for 1.18, also added release compiled jar.

Tested on [Age Of Fate: Frozen Hope](https://legacy.curseforge.com/minecraft/modpacks/age-of-fate-the-frozen-hope) modpack in both SP and local server with friend. No any additional issues met.